### PR TITLE
Hi Dain, I'm using your iOS pie chart in an application at work and found a small bug when creating pie charts that are not full screen. Great class and thanks for sharing it!

### DIFF
--- a/PieChartViewExample/Classes/PieChartView.m
+++ b/PieChartViewExample/Classes/PieChartView.m
@@ -130,8 +130,8 @@
 	float startDeg = 0;
 	float endDeg = 0;
 	
-	int x = self.center.x;
-	int y = self.center.y;
+	int x = self.bounds.size.width / 2;
+	int y = self.bounds.size.height / 2;
 	int r = (self.bounds.size.width>self.bounds.size.height?self.bounds.size.height:self.bounds.size.width)/2 * 0.8;
 	
 	CGContextRef ctx = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
...rent view.

This problem occurs because the drawRect method draws using an x and y that is based on
the views center property which returns values in the superviews coordinate system where
the drawRect expects values that are in the views coordinate system.

To see this bug in action resize the PieChartView to 100x100 and place it in the top
right corner.
