### PR TITLE
Add settings to control the line around the circle

### DIFF
--- a/PieChartViewExample/Classes/PieChartView.h
+++ b/PieChartViewExample/Classes/PieChartView.h
@@ -27,10 +27,12 @@ PieChartItemColor PieChartItemColorFromColor(UIColor *color);
 	float _sum;
 	PieChartItemColor _noDataFillColor;
 	PieChartItemColor _gradientFillColor;
+	PieChartItemColor _lineAroundStrokeColor;
 	
     BOOL _drawGradientOverlay;
 	float _gradientStart;
 	float _gradientEnd;
+   	float _lineAroundSpacing;
 }
 
 - (void)clearItems;
@@ -40,6 +42,9 @@ PieChartItemColor PieChartItemColorFromColor(UIColor *color);
 - (void)setGradientFillColorRed:(float)r green:(float)g blue:(float)b;
 - (void)setGradientFillColor:(PieChartItemColor)color;
 - (void)setDrawGradientOverlay:(BOOL)drawGradientOverlay;
+- (void)setLineAroundSpacing:(float)spacing;
+- (void)setLineAroundColorRed:(float)r green:(float)g blue:(float)b;
+- (void)setLineAroundColor:(PieChartItemColor)color;
 
 // Values ranging from 0.0-1.0 specifying where to begin/end the fills. 
 // E.g. A start of 0.0 starts at the top of the piechart, and 0.3 starts a third of the way from the top.

--- a/PieChartViewExample/Classes/PieChartView.m
+++ b/PieChartViewExample/Classes/PieChartView.m
@@ -65,6 +65,8 @@ PieChartItemColor PieChartItemColorFromColor(UIColor *color)
 	_gradientFillColor = PieChartItemColorMake(0.0, 0.0, 0.0, 0.4);
 	_gradientStart = 0.3;
 	_gradientEnd = 1.0;
+    _lineAroundStrokeColor = PieChartItemColorMake(0.0, 0.0, 0.0, 0.4);
+    _lineAroundSpacing = 0.0;
 	_drawGradientOverlay = YES;
 	self.backgroundColor = [UIColor clearColor];
 	
@@ -162,6 +164,24 @@ PieChartItemColor PieChartItemColorFromColor(UIColor *color)
     [self setNeedsDisplay];
 }
 
+- (void)setLineAroundColorRed:(float)r green:(float)g blue:(float)b
+{
+	_lineAroundStrokeColor = PieChartItemColorMake(r, g, b, 0.4);
+    [self setNeedsDisplay];
+}
+
+- (void)setLineAroundColor:(PieChartItemColor)color
+{
+	_lineAroundStrokeColor = color;
+    [self setNeedsDisplay];
+}
+
+- (void)setLineAroundSpacing:(float)spacing
+{
+	_lineAroundSpacing = spacing;
+    [self setNeedsDisplay];
+}
+
 // Only override drawRect: if you perform custom drawing.
 // An empty implementation adversely affects performance during animation.
 - (void)drawRect:(CGRect)rect {
@@ -174,11 +194,11 @@ PieChartItemColor PieChartItemColorFromColor(UIColor *color)
 	float r = (self.bounds.size.width>self.bounds.size.height?self.bounds.size.height:self.bounds.size.width)/2 * 0.8;
 	
 	CGContextRef ctx = UIGraphicsGetCurrentContext();
-	CGContextSetRGBStrokeColor(ctx, 0.0, 0.0, 0.0, 0.4);
+	CGContextSetRGBStrokeColor(ctx, _lineAroundStrokeColor.red, _lineAroundStrokeColor.green, _lineAroundStrokeColor.blue, _lineAroundStrokeColor.alpha);
 	CGContextSetLineWidth(ctx, 1.0);
 	
 	// Draw a thin line around the circle
-	CGContextAddArc(ctx, x, y, r, 0.0, 360.0*M_PI/180.0, 0);
+	CGContextAddArc(ctx, x, y, r + _lineAroundSpacing, 0.0, 360.0*M_PI/180.0, 0);
 	CGContextClosePath(ctx);
 	CGContextDrawPath(ctx, kCGPathStroke);
 	


### PR DESCRIPTION
With this change, you can control the color of the line around the circle (or disable it by using alpha 0) and add some space between it and the chart points.
